### PR TITLE
Include “The” in the anthology show-notes link

### DIFF
--- a/lib/show_notes.rb
+++ b/lib/show_notes.rb
@@ -18,7 +18,7 @@ module ShowNotes
       paragraphs = [
         "#{h episode[:label]} on <em>#{h episode[:show_name]}</em>, #{date(episode)}.",
         links(episode),
-        "Collected in the #{link(site_url, NAME)}. #{RIGHTS}"
+        "Collected in #{link(site_url, "The #{NAME}")}. #{RIGHTS}"
       ]
 
       paragraphs.compact.map { |paragraph| "<p>#{paragraph}</p>" }.join("\n")
@@ -29,7 +29,7 @@ module ShowNotes
     def text(episode)
       sentences = ["#{episode[:label]} on #{episode[:show_name]}, #{date(episode)}."]
       sentences << "Original: #{episode[:page_url]}" if episode[:page_url]
-      sentences << "Collected in the #{NAME}. #{RIGHTS}"
+      sentences << "Collected in The #{NAME}. #{RIGHTS}"
       sentences.join("\n\n")
     end
 

--- a/test/show_notes_test.rb
+++ b/test/show_notes_test.rb
@@ -34,7 +34,8 @@ class ShowNotesTest < Minitest::Test
   def test_links_the_anthology_and_names_whose_the_episode_is
     notes = ShowNotes.html(episode, site_url: SITE)
 
-    assert_includes notes, "<a href=\"#{SITE}\">David Deutsch Anthology</a>"
+    assert_includes notes, "<a href=\"#{SITE}\">The David Deutsch Anthology</a>"
+    refute_includes notes, "the <a href=\"#{SITE}\">"
     assert_includes notes, ShowNotes::RIGHTS
   end
 
@@ -62,6 +63,7 @@ class ShowNotesTest < Minitest::Test
 
     assert_includes text, 'Interview on EconTalk, 11 January 2024.'
     assert_includes text, 'Original: https://econtalk.org/deutsch'
+    assert_includes text, 'Collected in The David Deutsch Anthology.'
     refute_match(/<[a-z]/, text)
   end
 end


### PR DESCRIPTION
Podcast clients currently show “Collected in the **David Deutsch Anthology**” with only the title linked. This puts “The” inside the link: “Collected in **The David Deutsch Anthology**”.

- `lib/show_notes.rb` HTML and itunes summary
- `test/show_notes_test.rb`